### PR TITLE
test: make web diagnostics color smoke deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1145,6 +1145,7 @@
     "test:workflow-contracts": "node -r ./tests/helpers/strictConsole.js tests/test-workflow-script-contracts.js",
     "test:freshness-policy-logging": "node -r ./tests/helpers/strictConsole.js tests/test-freshness-policy-logging.js",
     "test:warning-filters": "node -r ./tests/helpers/strictConsole.js tests/test-warning-filters-scope.js",
+    "test:web-config-event-contract": "node tests/test-web-config-event-contract.js",
     "test:dist-parity": "node scripts/check-dist-parity.js",
     "test:config-audit": "node -r ./tests/helpers/strictConsole.js tests/test-schema-audit.js",
     "test:config-scenarios": "node -r ./tests/helpers/strictConsole.js tests/test-configuration-scenarios.js",

--- a/tests/helpers/createWebVscodeMock.js
+++ b/tests/helpers/createWebVscodeMock.js
@@ -368,6 +368,7 @@ function createWebVscodeMock(options = {}) {
     const commandCalls = [];
     const commandRegistry = new Map();
     let fileWatcherCount = 0;
+    const configChangeListeners = new Set();
 
     const resolveWorkspaceFolderValue = (fullKey) => {
         if (Object.prototype.hasOwnProperty.call(workspaceFolderConfigStore, fullKey)) {
@@ -399,6 +400,12 @@ function createWebVscodeMock(options = {}) {
             setValue(configStore, fullKey, value);
         }
         appliedUpdates.push({ key: fullKey, value, target: targetLabel });
+        const event = {
+            affectsConfiguration(section) {
+                return !section || fullKey === section || fullKey.startsWith(`${section}.`);
+            }
+        };
+        configChangeListeners.forEach((listener) => listener(event));
     };
 
     const makeSectionConfig = (section = '') => {
@@ -470,8 +477,13 @@ function createWebVscodeMock(options = {}) {
         createFileSystemWatcher() {
             throw new Error('workspace.createFileSystemWatcher is unavailable in web environments');
         },
-        onDidChangeConfiguration() {
-            return { dispose() {} };
+        onDidChangeConfiguration(listener) {
+            configChangeListeners.add(listener);
+            return {
+                dispose() {
+                    configChangeListeners.delete(listener);
+                }
+            };
         },
         workspaceFolders: workspaceFolderEntries,
         fs: workspaceFs,

--- a/tests/test-web-bundle-smoke.js
+++ b/tests/test-web-bundle-smoke.js
@@ -143,7 +143,14 @@ async function runWebSmokeTest() {
             assert.ok(provider && typeof provider.provideFileDecoration === 'function', 'Web bundle should register a file decoration provider');
             const sampleFile = path.join(extensionRoot, 'tests', 'fixtures', 'sample-workspace', 'package.json');
             const sampleUri = harness.vscode.Uri.file(sampleFile).with({ scheme: 'vscode-vfs' });
-            await provider.provideFileDecoration(sampleUri);
+            const originalStat = fs.statSync(sampleFile);
+            const eligibleMtime = new Date(Date.now() - 10 * 60 * 1000);
+            fs.utimesSync(sampleFile, originalStat.atime, eligibleMtime);
+            try {
+                await provider.provideFileDecoration(sampleUri);
+            } finally {
+                fs.utimesSync(sampleFile, originalStat.atime, originalStat.mtime);
+            }
 
             const logText = diagState.logs
                 .map((entry) => `${entry.level}:${entry.message} ${(entry.meta && entry.meta.error) || ''}`)

--- a/tests/test-web-config-event-contract.js
+++ b/tests/test-web-config-event-contract.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const { createWebVscodeMock } = require('./helpers/createWebVscodeMock');
+
+async function main() {
+    const harness = createWebVscodeMock();
+    let event = null;
+    const disposable = harness.vscode.workspace.onDidChangeConfiguration((change) => { event = change; });
+    try {
+        await harness.vscode.workspace.getConfiguration('explorerDates').update('colorScheme', 'recency', harness.vscode.ConfigurationTarget.Global);
+        assert.ok(event, 'configuration update should emit an event');
+        assert.strictEqual(event.affectsConfiguration('explorerDates'), true);
+        assert.strictEqual(event.affectsConfiguration('explorerDates.colorScheme'), true);
+        assert.strictEqual(harness.vscode.workspace.getConfiguration('explorerDates').get('colorScheme'), 'recency');
+        console.log('Web configuration event contract passed.');
+    } finally {
+        disposable.dispose();
+        harness.restore();
+    }
+}
+
+main().catch((error) => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
## Summary
- make the web diagnostics smoke fixture use an eligible virtual-filesystem timestamp
- restore the original fixture timestamp after the test
- make the VS Code web mock emit realistic configuration-change events with `affectsConfiguration()` semantics
- add a focused configuration-event contract
## Source identity
- Base branch: `release/1.3`
- Original base SHA: `2b029420cfe837a569fa36217a14e0655481dbc0`
- Head SHA: `8500351b6e950af571666307001b6ba9548307ab`
- Tree SHA: `692ffc03abe009fa33e53e4d5afcfeed09119c1e`
- Patch SHA-256: `21cc625cee00f43b5e21dbe6dcd22548997c1142eb6fa3cf135620cee342ca54`
## Root cause
The original sample file was only seconds old. Virtual-filesystem timestamps younger than five minutes are intentionally treated as untrusted, so freshness resolved to `unknown` and diagnostics correctly reported a colorless decoration.
The test now uses an eligible temporary timestamp and restores the original timestamp afterward.
The web mock also previously accepted `config.update()` without emitting `onDidChangeConfiguration`. It now models VS Code configuration-change events with `affectsConfiguration()` semantics.
## Scope
Exactly four files:
- `package.json`
- `tests/helpers/createWebVscodeMock.js`
- `tests/test-web-bundle-smoke.js`
- `tests/test-web-config-event-contract.js`
This PR excludes:
- activation API export changes
- source-map parity changes
- Pro code
- licensing or payments
- product features
- release or publication changes
- deployment or Marketplace changes
## Validation
Passed locally:
- focused web configuration-event contract
- development web-bundle smoke
- production web-bundle smoke
- production artifact parity using `npm run package-bundle`
- lint
- feature-gate tests
- critical tests
- bundle checks
- bundle verification
- full test suite: 93 tests
- `git diff --check`
## Ordering
This baseline repair should merge before the separate activation API export PR so the activation repair can run against a green public-core validation baseline.
No release or publication is authorized.
