### PR TITLE
ci: validate pull requests targeting release/1.3

### DIFF
--- a/.github/workflows/public-pr-validation.yml
+++ b/.github/workflows/public-pr-validation.yml
@@ -1,0 +1,88 @@
+name: Public PR Validation
+
+on:
+  pull_request:
+    branches:
+      - release/1.3
+  push:
+    branches:
+      - release/1.3
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Public PR Contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CI: "true"
+      NODE_ENV: test
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run critical tests
+        run: npm run test:critical
+
+      - name: Run feature-gate tests
+        run: npm run test:feature-gates
+
+      - name: Generate production bundles
+        run: npm run package-bundle
+
+      - name: Confirm production generation scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          unexpected=()
+          while IFS= read -r path; do
+            case "$path" in
+              dist/*) ;;
+              "") ;;
+              *) unexpected+=("$path") ;;
+            esac
+          done < <(git diff --name-only)
+          if [ "${#unexpected[@]}" -ne 0 ]; then
+            printf 'Unexpected tracked changes after production generation:\n%s\n' "${unexpected[*]}"
+            exit 1
+          fi
+
+      - name: Verify production artifact parity
+        run: npm run test:dist-parity
+
+      - name: Check production whitespace
+        run: git diff --check
+
+      - name: Verify bundle integrity
+        run: npm run test:bundle
+
+      - name: Verify production bundles
+        run: npm run test:verify-bundle
+
+      - name: Run web bundle smoke
+        run: node -r ./tests/helpers/strictConsole.js tests/test-web-bundle-smoke.js
+
+      - name: Run full test suite
+        run: npm run test:suite
+
+      - name: Remove non-authoritative compile output
+        run: |
+          git restore --worktree -- dist src/locales tests/fixtures/sample-workspace/.explorer-dates-profiles.json
+
+      - name: Check whitespace
+        run: git diff --check

--- a/.github/workflows/public-pr-validation.yml
+++ b/.github/workflows/public-pr-validation.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - release/1.3
   workflow_dispatch:
+    inputs:
+      validation_ref:
+        description: Exact commit SHA to validate
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -21,14 +26,79 @@ jobs:
       CI: "true"
       NODE_ENV: test
     steps:
+      - name: Resolve validation identity
+        id: resolve-validation
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_VALIDATION_SHA: ${{ inputs.validation_ref || '' }}
+          EVENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [[ ! "$REQUESTED_VALIDATION_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "workflow_dispatch validation_ref must be a full lowercase 40-character SHA"
+              exit 1
+            fi
+            expected="$REQUESTED_VALIDATION_SHA"
+          else
+            expected="$EVENT_SHA"
+          fi
+          echo "EXPECTED_VALIDATION_SHA=$expected" >> "$GITHUB_ENV"
+          echo "expected_sha=$expected" >> "$GITHUB_OUTPUT"
+
       - name: Check out source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.validation_ref || github.sha }}
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+
+      - name: Verify and record validation identity
+        shell: bash
+        env:
+          REQUESTED_VALIDATION_SHA: ${{ inputs.validation_ref || '' }}
+          EXPECTED_VALIDATION_SHA: ${{ steps.resolve-validation.outputs.expected_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          test "$actual" = "$EXPECTED_VALIDATION_SHA"
+          mkdir -p validation-identity
+          node - <<'NODE'
+          const fs = require('fs');
+          const identity = {
+            requested_sha: process.env.REQUESTED_VALIDATION_SHA,
+            resolved_head: process.env.EXPECTED_VALIDATION_SHA,
+            repository: process.env.REPOSITORY,
+            workflow_run_id: process.env.RUN_ID,
+            event_name: process.env.EVENT_NAME
+          };
+          fs.writeFileSync('validation-identity/identity.json', `${JSON.stringify(identity, null, 2)}\n`);
+          NODE
+          {
+            echo '## Validated commit'
+            echo
+            echo "- Requested SHA: \\`$REQUESTED_VALIDATION_SHA\\`"
+            echo "- Resolved HEAD: \\`$actual\\`"
+            echo "- Event: \\`$EVENT_NAME\\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload validation identity
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-identity-${{ github.run_id }}
+          path: validation-identity/identity.json
+          if-no-files-found: warn
+          retention-days: 7
 
       - name: Install dependencies
         run: npm ci

--- a/tests/test-public-pr-ci-contract.js
+++ b/tests/test-public-pr-ci-contract.js
@@ -26,7 +26,11 @@ function main() {
     assert(workflow.on && workflow.on.pull_request, 'Workflow must define pull_request');
     assert.deepStrictEqual(workflow.on.pull_request.branches, ['release/1.3']);
     assert.deepStrictEqual(workflow.on.push.branches, ['release/1.3']);
-    assert(workflow.on.workflow_dispatch !== undefined, 'Workflow must support workflow_dispatch');
+    const dispatch = workflow.on.workflow_dispatch;
+    assert(dispatch && dispatch.inputs && dispatch.inputs.validation_ref, 'workflow_dispatch must require validation_ref');
+    assert.strictEqual(dispatch.inputs.validation_ref.required, true);
+    assert.strictEqual(dispatch.inputs.validation_ref.type, 'string');
+    assert.strictEqual(dispatch.inputs.validation_ref.description, 'Exact commit SHA to validate');
     assert.deepStrictEqual(workflow.permissions, { contents: 'read' });
 
     const jobs = Object.values(workflow.jobs || {});
@@ -43,6 +47,14 @@ function main() {
     assert(!workflow.on.pull_request.paths && !workflow.on.pull_request['paths-ignore'], 'Source changes must not bypass validation by path');
     assert(source.includes('node-version: 20'), 'Workflow must pin the supported Node version');
     assert(source.includes('cache: npm'), 'Workflow must enable npm caching');
+    assert(source.includes('^[0-9a-f]{40}$'), 'Manual validation must require a full lowercase SHA');
+    assert(source.includes('inputs.validation_ref || github.sha'), 'Checkout must select the exact manual SHA or event SHA');
+    assert(runs.includes('git rev-parse HEAD'), 'Workflow must verify the checked-out HEAD');
+    assert(runs.includes('EXPECTED_VALIDATION_SHA'), 'Workflow must compare HEAD with the resolved SHA');
+    assert(runs.includes('GITHUB_STEP_SUMMARY'), 'Workflow must summarize the validated SHA');
+    assert(source.includes('actions/upload-artifact@v4'), 'Workflow must upload validation identity');
+    assert(source.includes('validation-identity/identity.json'), 'Workflow must define the identity artifact');
+    assert(source.includes('github.event_name'), 'Workflow must preserve event-specific validation behavior');
 
     const requiredCommands = [
         'npm ci',

--- a/tests/test-public-pr-ci-contract.js
+++ b/tests/test-public-pr-ci-contract.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const repoRoot = path.join(__dirname, '..');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'public-pr-validation.yml');
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const source = fs.readFileSync(workflowPath, 'utf8');
+const workflow = yaml.load(source, { schema: yaml.JSON_SCHEMA });
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+function stepsFor(job) {
+    return job.steps || [];
+}
+
+function runText(step) {
+    return typeof step.run === 'string' ? step.run : '';
+}
+
+function main() {
+    assert(workflow && typeof workflow === 'object', 'Public PR workflow must parse as YAML');
+    assert.strictEqual(workflow.name, 'Public PR Validation');
+    assert(workflow.on && workflow.on.pull_request, 'Workflow must define pull_request');
+    assert.deepStrictEqual(workflow.on.pull_request.branches, ['release/1.3']);
+    assert.deepStrictEqual(workflow.on.push.branches, ['release/1.3']);
+    assert(workflow.on.workflow_dispatch !== undefined, 'Workflow must support workflow_dispatch');
+    assert.deepStrictEqual(workflow.permissions, { contents: 'read' });
+
+    const jobs = Object.values(workflow.jobs || {});
+    assert.strictEqual(jobs.length, 1, 'Public PR contract should have one authoritative job');
+    const job = jobs[0];
+    assert.strictEqual(job['runs-on'], 'ubuntu-latest');
+    assert(Number.isInteger(job['timeout-minutes']) && job['timeout-minutes'] > 0, 'Job needs a timeout');
+    assert(!('if' in job), 'Draft PRs and ordinary pull requests must not be excluded by a job condition');
+
+    const steps = stepsFor(job);
+    const runs = steps.map(runText).join('\n');
+    assert(!/continue-on-error\s*:/i.test(source), 'Required validation cannot use continue-on-error');
+    assert(!/draft/i.test(source), 'Draft PRs must not be excluded');
+    assert(!workflow.on.pull_request.paths && !workflow.on.pull_request['paths-ignore'], 'Source changes must not bypass validation by path');
+    assert(source.includes('node-version: 20'), 'Workflow must pin the supported Node version');
+    assert(source.includes('cache: npm'), 'Workflow must enable npm caching');
+
+    const requiredCommands = [
+        'npm ci',
+        'npm run lint',
+        'npm run test:critical',
+        'npm run test:feature-gates',
+        'npm run package-bundle',
+        'npm run test:dist-parity',
+        'npm run test:bundle',
+        'npm run test:verify-bundle',
+        'node -r ./tests/helpers/strictConsole.js tests/test-web-bundle-smoke.js',
+        'npm run test:suite',
+        'git diff --check'
+    ];
+    for (const command of requiredCommands) {
+        assert(runs.includes(command), `Missing required validation command: ${command}`);
+    }
+
+    const packageIndex = runs.indexOf('npm run package-bundle');
+    const parityIndex = runs.indexOf('npm run test:dist-parity');
+    assert(packageIndex >= 0 && parityIndex > packageIndex, 'Production parity must run after package-bundle');
+    assert(runs.includes('git diff --name-only'), 'Workflow must check production generation scope');
+    assert(runs.includes('git restore --worktree -- dist'), 'Workflow must remove non-authoritative compile output');
+    assert(!source.includes('npm publish') && !source.includes('vsce publish'), 'Validation workflow must not publish');
+
+    const definedScripts = new Set(Object.keys(packageJson.scripts || {}));
+    const referencedScripts = [...runs.matchAll(/npm run ([A-Za-z0-9:_-]+)/g)].map((match) => match[1]);
+    const missingScripts = referencedScripts.filter((script) => !definedScripts.has(script));
+    assert.deepStrictEqual(missingScripts, [], `Workflow references nonexistent npm scripts: ${missingScripts.join(', ')}`);
+
+    console.log(`✅ Public PR CI contract validated: ${requiredCommands.length} required commands and structured workflow policy checks passed.`);
+}
+
+main();

--- a/tests/test-workflow-script-contracts.js
+++ b/tests/test-workflow-script-contracts.js
@@ -44,6 +44,8 @@ function main() {
         `Missing npm scripts referenced by workflows:\n${missing.map((item) => `- ${item.script} (${item.workflow})`).join('\n')}`
     );
 
+    require('./test-public-pr-ci-contract.js');
+
     console.log(`✅ Workflow contract validated: ${workflowScripts.length} npm run references map to package.json scripts.`);
 }
 


### PR DESCRIPTION
## Summary
- add one authoritative public PR validation workflow for pull requests targeting `release/1.3`
- preserve `Memory Regression` as a manually/scheduled gated workflow rather than treating its skipped PR job as validation
- add structured workflow contract tests covering triggers, permissions, required commands, ordering, script validity, and bypass protections

## Base identity
- Base branch: `release/1.3`
- Exact base SHA before work: `2b029420cfe837a569fa36217a14e0655481dbc0`
- CI branch head SHA: `0034851e822a78a25191293ca81f9ce5f57a76f9`

## Why PRs #38 and #39 received only skipped checks
The public repository's substantive workflows were filtered to `main` and therefore did not target `release/1.3`. `Memory Regression` accepts `pull_request` events, but its `memory` job condition only allows `workflow_dispatch` or `schedule`, so the pull-request job was skipped. The exact heads therefore exposed only the completed/skipped `Memory Regression` check.

## Workflow trigger audit
The new `Public PR Validation` workflow targets `pull_request` and `push` for `release/1.3`, plus `workflow_dispatch`. It has read-only contents permission, Node 20, npm caching, a timeout, no draft exclusion, no path bypass, no publishing credentials, and no release step.

## Required validation contract
The workflow runs:
- clean `npm ci`
- lint
- critical tests
- feature-gate tests
- production `package-bundle`
- production artifact parity
- bundle integrity
- bundle verification
- web bundle smoke
- full 93-test suite
- `git diff --check`

Production authority remains `package-bundle-production`; compile output is treated as non-authoritative and cleaned before final whitespace validation. Production generation is checked for unexpected tracked changes.

## Files changed
- `.github/workflows/public-pr-validation.yml`
- `tests/test-public-pr-ci-contract.js`
- `tests/test-workflow-script-contracts.js`

## Local validation
Passed:
- structured workflow YAML parsing
- `npm ci`
- `npm run lint`
- `npm run test:workflow-contracts`
- `npm run test:critical`
- `npm run test:feature-gates`
- `npm run package-bundle`
- `npm run test:dist-parity`
- `npm run test:bundle`
- `npm run test:verify-bundle`
- web bundle smoke
- `npm run test:suite` — 93 passed
- `git diff --check`

No product source behavior changed. PRs #38 and #39 remain separate, draft, and unmerged. This PR does not refresh or merge either repair PR.
